### PR TITLE
Add click version options and update setup.py to include README.md info

### DIFF
--- a/{{cookiecutter.project_slug}}/setup.py
+++ b/{{cookiecutter.project_slug}}/setup.py
@@ -11,6 +11,17 @@ def get_version():
         )
     ) as f:
         return f.readline().strip()
+    
+
+def get_description():
+    with open("README.md", "r") as fh:
+        long_description = fh.read()
+    return long_description
+
+
+def get_data_files():
+    data_files = [(".", ["README.md"])]
+    return data_files
 
 
 CLASSIFIERS = [
@@ -33,9 +44,12 @@ setup(
     url="{{cookiecutter.project_url}}",
     python_requires="{{cookiecutter.min_python_version}}",
     description="{{cookiecutter.project_description}}",
+    long_description=get_description(),
+    long_description_content_type="text/markdown",
     version=get_version(),
     author="{{cookiecutter.full_name}}",
     author_email="{{cookiecutter.email}}",
+    data_files=get_data_files(),
     py_modules=["{{cookiecutter.project_slug}}"],
     install_requires=[
         "snakemake{{cookiecutter.snakemake_version}}",

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/__main__.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/__main__.py
@@ -84,7 +84,8 @@ def common_options(func):
 )
 @click.version_option(get_version(), "-v", "--version", is_flag=True)
 def cli():
-    """For more options, run:
+    """{{cookiecutter.project_description}}. 
+    For more options, run:
     {{cookiecutter.project_slug}} command --help"""
     pass
 

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/__main__.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/__main__.py
@@ -11,6 +11,7 @@ import click
 from .util import (
     snake_base,
     print_version,
+    get_version,
     default_to_output,
     copy_config,
     run_snakemake,
@@ -82,6 +83,7 @@ def common_options(func):
 @click.group(
     cls=OrderedCommands, context_settings=dict(help_option_names=["-h", "--help"])
 )
+@click.version_option(get_version(), "-v", "--version", is_flag=True)
 def cli():
     """For more options, run:
     {{cookiecutter.project_slug}} command --help"""

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/__main__.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/__main__.py
@@ -10,7 +10,6 @@ import click
 
 from .util import (
     snake_base,
-    print_version,
     get_version,
     default_to_output,
     copy_config,

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/__main__.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/__main__.py
@@ -84,7 +84,8 @@ def common_options(func):
 )
 @click.version_option(get_version(), "-v", "--version", is_flag=True)
 def cli():
-    """{{cookiecutter.project_description}}. 
+    """{{cookiecutter.project_description}}
+    \b
     For more options, run:
     {{cookiecutter.project_slug}} command --help"""
     pass

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/__main__.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/__main__.py
@@ -152,7 +152,6 @@ cli.add_command(citation)
 
 
 def main():
-    print_version()
     cli()
 
 

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/util.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/util.py
@@ -28,6 +28,12 @@ def print_version():
     echo_click("\n" + "{{cookiecutter.project_name}} version " + version + "\n")
 
 
+def get_version():
+    with open(snake_base("{{cookiecutter.project_slug}}.VERSION"), "r") as f:
+        version = f.readline()
+    return version
+
+
 def echo_click(msg, log=None):
     click.echo(msg, nl=False, err=True)
     if log:

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/util.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/util.py
@@ -22,12 +22,6 @@ def snake_base(rel_path):
     return os.path.join(os.path.dirname(os.path.realpath(__file__)), rel_path)
 
 
-def print_version():
-    with open(snake_base("{{cookiecutter.project_slug}}.VERSION"), "r") as f:
-        version = f.readline()
-    echo_click("\n" + "{{cookiecutter.project_name}} version " + version + "\n")
-
-
 def get_version():
     with open(snake_base("{{cookiecutter.project_slug}}.VERSION"), "r") as f:
         version = f.readline()


### PR DESCRIPTION
This PR includes the following changes to support PyPI release.

* Use `click.version_option` to print out the tool version with `-v` option
* Add `description` in `cli()`
* Add files and README file as `data_files` in `setup.py`
* Add `long_description` from README file in `setup.py`